### PR TITLE
:art: remove internal prefix on preview

### DIFF
--- a/app/src/main/java/com/demo/utech/screenshottesting/ui/components/CallCard.kt
+++ b/app/src/main/java/com/demo/utech/screenshottesting/ui/components/CallCard.kt
@@ -51,7 +51,7 @@ fun CallCard(
 
 @Composable
 @PreviewLightDark
-internal fun CallCardPreview() {
+fun CallCardPreview() {
     AppTheme {
         CallCard("Robin")
     }

--- a/app/src/main/java/com/demo/utech/screenshottesting/ui/directory/DirectoryScreen.kt
+++ b/app/src/main/java/com/demo/utech/screenshottesting/ui/directory/DirectoryScreen.kt
@@ -72,7 +72,7 @@ fun DirectoryScreen(
 
 @Composable
 @PreviewLightDark
-internal fun DirectoryScreenPreview(
+fun DirectoryScreenPreview(
     @PreviewParameter(ContactProvider::class) directory: List<Contact>
 ) {
     AppTheme {


### PR DESCRIPTION
This pull request includes changes to the `CallCard.kt` and `DirectoryScreen.kt` files to modify the visibility of preview functions. The most important changes are:

Visibility modifications:

* [`app/src/main/java/com/demo/utech/screenshottesting/ui/components/CallCard.kt`](diffhunk://#diff-3cc44705fefaab220d64430313c0ece8466498081487a469c82115442d7c1381L54-R54): Changed the visibility of the `CallCardPreview` function from `internal` to public.
* [`app/src/main/java/com/demo/utech/screenshottesting/ui/directory/DirectoryScreen.kt`](diffhunk://#diff-73fe0125b848604dbdee52ca2d7cc9e2a22d920e61a34f35867900832866e8bcL75-R75): Changed the visibility of the `DirectoryScreenPreview` function from `internal` to public.